### PR TITLE
fix: use correct season for anime

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,13 @@ on:
       - 'README.md'
       - '.gitignore'
       - '.gitattributes'
+  pull_request:
+    branches:
+      - '*'
+    paths-ignore:
+      - 'README.md'
+      - '.gitignore'
+      - '.gitattributes'
 
 jobs:
   build:

--- a/src/main/kotlin/io/github/manamiproject/modb/kitsu/KitsuConverter.kt
+++ b/src/main/kotlin/io/github/manamiproject/modb/kitsu/KitsuConverter.kt
@@ -127,10 +127,10 @@ class KitsuConverter(
         val year = Regex("[0-9]{4}").find(startDate)?.value?.toInt() ?: 0
 
         val season = when(month) {
-            1,2,3 -> AnimeSeason.Season.WINTER
-            4,5,6 -> AnimeSeason.Season.SPRING
-            7,8,9 -> AnimeSeason.Season.SUMMER
-            10, 11, 12 -> AnimeSeason.Season.FALL
+            12, 1, 2 -> AnimeSeason.Season.WINTER
+            3, 4, 5 -> AnimeSeason.Season.SPRING
+            6, 7, 8 -> AnimeSeason.Season.SUMMER
+            9, 10, 11 -> AnimeSeason.Season.FALL
             else -> AnimeSeason.Season.UNDEFINED
         }
 


### PR DESCRIPTION
The season matching is 1 month ahead, leaving the earliest anime (usually a week or two) of each season in the previous season.

For consumers, the current behaviour would appear correct as the "Winter" season is media that airs between January and March, but that does not account for the edge cases like this.

`Youkai Watch Jam: Youkai Gakuen Y - N to no Souguu` started on December 27th 2019:

- `modb-kitsu` treats it as Fall 2019
- [`anilist`](https://anilist.co/anime/113472/Youkai-Watch-Jam-Youkai-Gakuen-Y--N-to-no-Souguu) treats it as Winter 2020
- [`kitsu`](https://kitsu.io/anime/youkai-watch-jam-youkai-gakuen-y-n-to-no-souguu) treats it as Winter 2020
- [`myanimelist`](https://myanimelist.net/anime/40714/Youkai_Watch_Jam__Youkai_Gakuen_Y_-_N_to_no_Souguu) treats it as Winter 2020
- `notify` does not have the entry

Kitsu version of https://github.com/manami-project/modb-notify/pull/1 and https://github.com/manami-project/modb-anidb/pull/1